### PR TITLE
ITHD-197691 Add Content Type to PUT Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ jobs:
       - run: ./deploy-release-for-demoapp14.sh
 
       - name: Annotate the release
-        uses: im-open/create-app-insights-annotation@v1.0.1
+        uses: im-open/create-app-insights-annotation@v1.0.2
         with:
           subscriptionId: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           resourceGroupName: ${{ env.RESOURCE_GROUP }}

--- a/action.yml
+++ b/action.yml
@@ -63,4 +63,4 @@ runs:
         $body = (ConvertTo-Json $annotation -Compress) -replace '(\\+)"', '$1$1"' -replace "`"", "`"`""
         Write-Host "Request Body:"
         Write-Host $body
-        az rest --method put --uri "$($aiResourceId)/Annotations?api-version=2015-05-01" --body "$($body) "
+        az rest --method put --uri "$($aiResourceId)/Annotations?api-version=2015-05-01" --body "$($body) --content-type application/json "

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
             Properties     = ConvertTo-Json $properties -Compress
         }
 
-        $body = (ConvertTo-Json $annotation -Compress) -replace '(\\+)"', '$1$1"' -replace "`"", "`"`""
+        $body = (ConvertTo-Json $annotation -Compress)
         Write-Host "Request Body:"
         Write-Host $body
         az rest --method put --uri "$($aiResourceId)/Annotations?api-version=2015-05-01" --body "$($body)" --headers "Content-Type=application/json"

--- a/action.yml
+++ b/action.yml
@@ -63,4 +63,4 @@ runs:
         $body = (ConvertTo-Json $annotation -Compress) -replace '(\\+)"', '$1$1"' -replace "`"", "`"`""
         Write-Host "Request Body:"
         Write-Host $body
-        az rest --method put --uri "$($aiResourceId)/Annotations?api-version=2015-05-01" --body "$($body) --content-type application/json "
+        az rest --method put --uri "$($aiResourceId)/Annotations?api-version=2015-05-01" --body "$($body)" --headers "{\"Content-Type\":\"application/json\"}"

--- a/action.yml
+++ b/action.yml
@@ -63,4 +63,4 @@ runs:
         $body = (ConvertTo-Json $annotation -Compress) -replace '(\\+)"', '$1$1"' -replace "`"", "`"`""
         Write-Host "Request Body:"
         Write-Host $body
-        az rest --method put --uri "$($aiResourceId)/Annotations?api-version=2015-05-01" --body "$($body)" --headers "{'Content-Type':'application/json'}"
+        az rest --method put --uri "$($aiResourceId)/Annotations?api-version=2015-05-01" --body "$($body)" --headers "Content-Type=application/json"

--- a/action.yml
+++ b/action.yml
@@ -63,4 +63,4 @@ runs:
         $body = (ConvertTo-Json $annotation -Compress) -replace '(\\+)"', '$1$1"' -replace "`"", "`"`""
         Write-Host "Request Body:"
         Write-Host $body
-        az rest --method put --uri "$($aiResourceId)/Annotations?api-version=2015-05-01" --body "$($body)" --headers "{\"Content-Type\":\"application/json\"}"
+        az rest --method put --uri "$($aiResourceId)/Annotations?api-version=2015-05-01" --body "$($body)" --headers "{'Content-Type':'application/json'}"


### PR DESCRIPTION
# Summary of PR changes
 [ITHD-197691](https://jira.extendhealth.com/browse/ITHD-197691) was created to address this issue. 
1. Explicitly add `application/json` to the headers so it's always present. Per the docs, [here](https://learn.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest#az-rest), it does this automatically if the body is JSON, but this issue cropped up because, I believe, it stopped thinking the body was valid JSON so it used a different Content Type. It wasn't until I added this block that we got a good error to go off of.
2. Remove the replacements when converting to JSON string. This seems like it may have been due to PowerShell being upgraded. The previous code seems to match what is in [Create release annotations with Azure CLI](https://learn.microsoft.com/en-us/azure/azure-monitor/app/annotations#create-release-annotations-with-azure-cli), but it no longer works. I found [this](https://github.com/PowerShell/PowerShell/issues/18540) issue in the latest PowerShell release; it's closed now but it leads me to believe it's related.
3. Updated Readme batch number so it would be correct in the docs. 

## Successful Build Against Changes
An action for the client-portal project completed with these changes in-place. See [Manually deploy AZ App Service](https://github.com/im-client/client-portal/actions/runs/3463371936/jobs/5783522667#step:11:1) for details.

## PR Requirements
- [x] For JavaScript actions, the action has been recompiled.  
  - See the *Recompiling* section of the repository's README.md for more details.
  - This does not apply to Composite Run Steps actions unless a package.json is present and contains a build script.
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
